### PR TITLE
feat: dns verification for cloud providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/google/go-github/v45 v45.2.0
 	github.com/hashicorp/vault/api v1.9.0
 	github.com/jedib0t/go-pretty/v6 v6.4.6
+	github.com/lixiangzhong/dnsutil v1.4.0
 	github.com/minio/minio-go/v7 v7.0.49
 	github.com/otiai10/copy v1.7.0
 	github.com/rs/zerolog v1.29.0
@@ -200,6 +201,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/miekg/dns v1.1.40 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -676,6 +676,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
+github.com/lixiangzhong/dnsutil v1.4.0 h1:S75ND4O8IbNhVdaP/Bn+3YHXPYvt6jpeqy3Yyr+iUNY=
+github.com/lixiangzhong/dnsutil v1.4.0/go.mod h1:hQj5Vdv9+/m5GZxu75Hp4SMPeYV3JZUABlUadwNVFmk=
 github.com/lpabon/godbc v0.1.1/go.mod h1:Jo9QV0cf3U6jZABgiJ2skINAXb9j8m51r07g4KI92ZA=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
@@ -718,6 +720,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/dns v1.1.40 h1:pyyPFfGMnciYUk/mXpKkVmeMQjfXqt3FAJ2hy7tPiLA=
+github.com/miekg/dns v1.1.40/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
@@ -1213,6 +1217,7 @@ golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1307,6 +1312,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191002063906-3421d5a6bb1c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1449,6 +1455,7 @@ golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191216173652-a0e659d51361/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -152,3 +152,16 @@ func (conf *AWSConfiguration) GetHostedZoneID(hostedZoneName string) (string, er
 
 	return hostedZoneId, nil
 }
+
+// GetHostedZone returns an object detailing a hosted zone
+func (conf *AWSConfiguration) GetHostedZone(hostedZoneID string) (*route53.GetHostedZoneOutput, error) {
+	route53Client := route53.NewFromConfig(conf.Config)
+	hostedZone, err := route53Client.GetHostedZone(context.Background(), &route53.GetHostedZoneInput{
+		Id: aws.String(hostedZoneID),
+	})
+	if err != nil {
+		log.Error().Msg(err.Error())
+	}
+
+	return hostedZone, nil
+}

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -1,0 +1,60 @@
+/*
+Copyright (C) 2021-2023, Kubefirst
+
+This program is licensed under MIT.
+See the LICENSE file for more details.
+*/
+package dns
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubefirst/runtime/pkg"
+	"github.com/lixiangzhong/dnsutil"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	CivoNameServers         []string = []string{"ns0.civo.com", "ns1.civo.com"}
+	DigitalOceanNameServers []string = []string{"ns1.digitalocean.com", "ns2.digitalocean.com", "ns3.digitalocean.com"}
+	VultrNameservers        []string = []string{"ns1.vultr.com", "ns2.vultr.com"}
+)
+
+// VerifyProviderDNS
+func VerifyProviderDNS(cloudProvider string, domainName string) error {
+	var dig dnsutil.Dig
+	var nameServers []string
+	dig.SetDNS("8.8.8.8")
+
+	switch cloudProvider {
+	case "civo":
+		nameServers = CivoNameServers
+	case "digitalocean":
+		nameServers = DigitalOceanNameServers
+	case "vultr":
+		nameServers = VultrNameservers
+	default:
+		return fmt.Errorf("unsupported cloud provider for dns verification: %s", cloudProvider)
+	}
+
+	records, err := dig.NS(domainName)
+	if err != nil {
+		return fmt.Errorf("error checking NS record for domain %s: %s", domainName, err)
+	}
+
+	var foundNSRecords []string
+	for _, rec := range records {
+		foundNSRecords = append(foundNSRecords, strings.TrimSuffix(rec.Ns, "."))
+	}
+
+	for _, reqrec := range nameServers {
+		if pkg.FindStringInSlice(foundNSRecords, reqrec) {
+			log.Info().Msgf("found NS record %s for domain %s", reqrec, domainName)
+		} else {
+			return fmt.Errorf("missing record %s for domain %s - please add the NS record", reqrec, domainName)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Allows verifying the presence of required NS records based on cloud provider and domain name.

```bash
❯ go run .
{"level":"info","time":"2023-04-23T18:37:46-04:00","message":"found NS record ns0.civo.com for domain your-dns.io"}
{"level":"info","time":"2023-04-23T18:37:46-04:00","message":"found NS record ns1.civo.com for domain your-dns.io"}

❯ go run .
{"level":"info","time":"2023-04-23T18:39:17-04:00","message":"found NS record ns1.digitalocean.com for domain kubefunk.de"}
{"level":"info","time":"2023-04-23T18:39:17-04:00","message":"found NS record ns2.digitalocean.com for domain kubefunk.de"}
{"level":"info","time":"2023-04-23T18:39:17-04:00","message":"found NS record ns3.digitalocean.com for domain kubefunk.de"}

❯ go run .
{"level":"info","time":"2023-04-23T18:40:09-04:00","message":"found NS record ns1.vultr.com for domain kubesecond.com"}
{"level":"info","time":"2023-04-23T18:40:09-04:00","message":"found NS record ns2.vultr.com for domain kubesecond.com"}
```

Implementation:

```go
	err := dns.VerifyProviderDNS("vultr", "kubesecond.com")
	if err != nil {
		fmt.Println(err)
	}
```