### PR TITLE
chore: fix error return logic

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -8,11 +8,11 @@ package configs
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"runtime"
 
 	"github.com/caarlos0/env/v6"
+	"github.com/rs/zerolog/log"
 )
 
 // DEPRECATED, will be removed in a future release
@@ -122,21 +122,16 @@ func ReadConfig() *Config {
 	config := Config{}
 
 	if err := env.Parse(&config); err != nil {
-		log.Println("something went wrong loading the environment variables")
-		log.Panic(err)
+		log.Error().Msgf("something went wrong loading the environment variables: %s", err)
 	}
 
 	homePath, err := os.UserHomeDir()
 	if err != nil {
-		log.Panic(err)
+		log.Error().Msgf("something went wrong getting home path: %s", err)
 	}
 
 	config.HomePath = homePath
 	config.K1FolderPath = fmt.Sprintf("%s/.k1", homePath)
-	if err != nil {
-		log.Panic(err)
-	}
-
 	config.GitopsDir = fmt.Sprintf("%s/.k1/gitops", homePath)
 	config.K1Dir = fmt.Sprintf("%s/.k1", homePath)
 
@@ -210,7 +205,7 @@ func ReadConfig() *Config {
 	// AWS SDK client will take it in advance
 	err = os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 	if err != nil {
-		log.Panicf("unable to set AWS_SDK_LOAD_CONFIG enviroment value, error is: %v", err)
+		log.Error().Msgf("unable to set AWS_SDK_LOAD_CONFIG enviroment value, error is: %v", err)
 	}
 
 	return &config

--- a/pkg/argocd/bootstrap.go
+++ b/pkg/argocd/bootstrap.go
@@ -167,7 +167,7 @@ func ApplyArgoCDKustomize(clientset *kubernetes.Clientset, argoCDInstallPath str
 	// Wait for the Job to finish
 	_, err = k8s.WaitForJobComplete(clientset, job, 240)
 	if err != nil {
-		log.Fatal().Msgf("could not run argocd bootstrap job: %s", err)
+		log.Error().Msgf("could not run argocd bootstrap job: %s", err)
 	}
 
 	// Cleanup

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -45,7 +45,7 @@ func NewAwsV2(region string) aws.Config {
 		config.WithSharedConfigProfile(profile),
 	)
 	if err != nil {
-		log.Panic().Msg("unable to create aws client")
+		log.Error().Msg("unable to create aws client")
 	}
 
 	return awsClient
@@ -62,7 +62,7 @@ func NewAwsV3(region string, accessKeyID string, secretAccessKey string, session
 		)),
 	)
 	if err != nil {
-		log.Panic().Msg("unable to create aws client")
+		log.Error().Msg("unable to create aws client")
 	}
 
 	return awsClient

--- a/pkg/aws/config.go
+++ b/pkg/aws/config.go
@@ -58,7 +58,7 @@ func GetConfig(clusterName string, domainName string, gitProvider string, gitOwn
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		log.Fatal().Msg(err.Error())
+		log.Error().Msgf("something went wrong getting home path: %s", err)
 	}
 
 	// cGitHost describes which git host to use depending on gitProvider

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -119,7 +119,7 @@ func (conf *AWSConfiguration) TestHostedZoneLiveness(hostedZoneName string) bool
 			}
 		}
 		if count == 100 {
-			log.Panic().Msg("unable to resolve hosted zone dns record. please check your domain registrar")
+			log.Error().Msg("unable to resolve hosted zone dns record. please check your domain registrar")
 		}
 	}
 	return true

--- a/pkg/bootstrap/serviceaccounts.go
+++ b/pkg/bootstrap/serviceaccounts.go
@@ -63,7 +63,8 @@ func ServiceAccounts(clientset *kubernetes.Clientset) error {
 		} else if strings.Contains(err.Error(), "not found") {
 			_, err = clientset.CoreV1().ServiceAccounts(serviceAccount.ObjectMeta.Namespace).Create(context.TODO(), serviceAccount, metav1.CreateOptions{})
 			if err != nil {
-				log.Fatal().Msgf("error creating kubernetes service account %s/%s: %s", serviceAccount.Namespace, serviceAccount.Name, err)
+				log.Error().Msgf("error creating kubernetes service account %s/%s: %s", serviceAccount.Namespace, serviceAccount.Name, err)
+				return err
 			}
 			log.Info().Msgf("created kubernetes service account: %s/%s", serviceAccount.Namespace, serviceAccount.Name)
 		}

--- a/pkg/civo/bootstrapSecrets.go
+++ b/pkg/civo/bootstrapSecrets.go
@@ -87,7 +87,8 @@ func BootstrapCivoMgmtCluster(civoToken string, kubeconfigPath string, gitProvid
 		} else if strings.Contains(err.Error(), "not found") {
 			_, err = clientset.CoreV1().Secrets(secret.ObjectMeta.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 			if err != nil {
-				log.Fatal().Msgf("error creating kubernetes secret %s/%s: %s", secret.Namespace, secret.Name, err)
+				log.Error().Msgf("error creating kubernetes secret %s/%s: %s", secret.Namespace, secret.Name, err)
+				return err
 			}
 			log.Info().Msgf("created kubernetes secret: %s/%s", secret.Namespace, secret.Name)
 		}
@@ -115,7 +116,8 @@ func BootstrapCivoMgmtCluster(civoToken string, kubeconfigPath string, gitProvid
 		} else if strings.Contains(err.Error(), "not found") {
 			_, err = clientset.CoreV1().ServiceAccounts(serviceAccount.ObjectMeta.Namespace).Create(context.TODO(), serviceAccount, metav1.CreateOptions{})
 			if err != nil {
-				log.Fatal().Msgf("error creating kubernetes service account %s/%s: %s", serviceAccount.Namespace, serviceAccount.Name, err)
+				log.Error().Msgf("error creating kubernetes service account %s/%s: %s", serviceAccount.Namespace, serviceAccount.Name, err)
+				return err
 			}
 			log.Info().Msgf("created kubernetes service account: %s/%s", serviceAccount.Namespace, serviceAccount.Name)
 		}

--- a/pkg/civo/civo.go
+++ b/pkg/civo/civo.go
@@ -35,8 +35,8 @@ func TestDomainLiveness(civoToken string, domainName string, domainId string, re
 
 	civoClient, err := civogo.NewClient(civoToken, region)
 	if err != nil {
-		log.Info().Msg(err.Error())
-		return log.Logger.Fatal().Stack().Enabled()
+		log.Error().Msg(err.Error())
+		return false
 	}
 
 	civoRecordConfig := &civogo.DNSRecordConfig{
@@ -95,7 +95,7 @@ func TestDomainLiveness(civoToken string, domainName string, domainId string, re
 			}
 		}
 		if count == 100 {
-			log.Panic().Msg("unable to resolve domain dns record. please check your domain registrar")
+			log.Error().Msg("unable to resolve domain dns record. please check your domain registrar")
 		}
 	}
 	return true

--- a/pkg/civo/config.go
+++ b/pkg/civo/config.go
@@ -8,11 +8,11 @@ package civo
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"runtime"
 
 	"github.com/kubefirst/runtime/pkg"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -61,7 +61,7 @@ func GetConfig(clusterName string, domainName string, gitProvider string, gitOwn
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		log.Panic(err.Error())
+		log.Error().Msgf("something went wrong getting home path: %s", err)
 	}
 
 	// cGitHost describes which git host to use depending on gitProvider

--- a/pkg/digitalocean/bootstrapSecrets.go
+++ b/pkg/digitalocean/bootstrapSecrets.go
@@ -80,7 +80,8 @@ func BootstrapDigitaloceanMgmtCluster(digitalOceanToken, kubeconfigPath string, 
 		} else if strings.Contains(err.Error(), "not found") {
 			_, err = clientset.CoreV1().Secrets(secret.ObjectMeta.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 			if err != nil {
-				log.Fatal().Msgf("error creating kubernetes secret %s/%s: %s", secret.Namespace, secret.Name, err)
+				log.Error().Msgf("error creating kubernetes secret %s/%s: %s", secret.Namespace, secret.Name, err)
+				return err
 			}
 			log.Info().Msgf("created kubernetes secret: %s/%s", secret.Namespace, secret.Name)
 		}
@@ -108,7 +109,8 @@ func BootstrapDigitaloceanMgmtCluster(digitalOceanToken, kubeconfigPath string, 
 		} else if strings.Contains(err.Error(), "not found") {
 			_, err = clientset.CoreV1().ServiceAccounts(serviceAccount.ObjectMeta.Namespace).Create(context.TODO(), serviceAccount, metav1.CreateOptions{})
 			if err != nil {
-				log.Fatal().Msgf("error creating kubernetes service account %s/%s: %s", serviceAccount.Namespace, serviceAccount.Name, err)
+				log.Error().Msgf("error creating kubernetes service account %s/%s: %s", serviceAccount.Namespace, serviceAccount.Name, err)
+				return err
 			}
 			log.Info().Msgf("created kubernetes service account: %s/%s", serviceAccount.Namespace, serviceAccount.Name)
 		}

--- a/pkg/digitalocean/config.go
+++ b/pkg/digitalocean/config.go
@@ -8,11 +8,11 @@ package digitalocean
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"runtime"
 
 	"github.com/kubefirst/runtime/pkg"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -61,7 +61,7 @@ func GetConfig(clusterName string, domainName string, gitProvider string, gitOwn
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		log.Panic(err.Error())
+		log.Error().Msgf("something went wrong getting home path: %s", err)
 	}
 
 	// cGitHost describes which git host to use depending on gitProvider

--- a/pkg/digitalocean/digitalocean.go
+++ b/pkg/digitalocean/digitalocean.go
@@ -89,7 +89,7 @@ func (c *DigitaloceanConfiguration) TestDomainLiveness(domainName string) bool {
 			}
 		}
 		if count == 100 {
-			log.Panic().Msg("unable to resolve domain dns record. please check your domain registrar")
+			log.Error().Msg("unable to resolve domain dns record. please check your domain registrar")
 		}
 	}
 	return true

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -18,7 +18,8 @@ import (
 func NewDockerClient() *client.Client {
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
-		log.Fatal().Msgf("error instantiating docker client: %s", err)
+		log.Error().Msgf("error instantiating docker client: %s", err)
+		return nil
 	}
 
 	return cli
@@ -27,7 +28,7 @@ func NewDockerClient() *client.Client {
 func (docker DockerClientWrapper) ListContainers() {
 	containers, err := docker.Client.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err != nil {
-		panic(err)
+		log.Error().Msg(err.Error())
 	}
 
 	for _, container := range containers {

--- a/pkg/downloadManager/download.go
+++ b/pkg/downloadManager/download.go
@@ -55,7 +55,7 @@ func DownloadFile(localFilename string, url string) error {
 func ExtractFileFromTarGz(gzipStream io.Reader, tarAddress string, targetFilePath string) {
 	uncompressedStream, err := gzip.NewReader(gzipStream)
 	if err != nil {
-		log.Panic().Msg("extractTarGz: NewReader failed")
+		log.Error().Msg("extractTarGz: NewReader failed")
 	}
 
 	tarReader := tar.NewReader(uncompressedStream)
@@ -66,7 +66,7 @@ func ExtractFileFromTarGz(gzipStream io.Reader, tarAddress string, targetFilePat
 			break
 		}
 		if err != nil {
-			log.Panic().Msgf("extractTarGz: Next() failed: %s", err.Error())
+			log.Error().Msgf("extractTarGz: Next() failed: %s", err.Error())
 		}
 		log.Info().Msg(header.Name)
 		if header.Name == tarAddress {
@@ -74,10 +74,10 @@ func ExtractFileFromTarGz(gzipStream io.Reader, tarAddress string, targetFilePat
 			case tar.TypeReg:
 				outFile, err := os.Create(targetFilePath)
 				if err != nil {
-					log.Panic().Msgf("extractTarGz: Create() failed: %s", err.Error())
+					log.Error().Msgf("extractTarGz: Create() failed: %s", err.Error())
 				}
 				if _, err := io.Copy(outFile, tarReader); err != nil {
-					log.Panic().Msgf("extractTarGz: Copy() failed: %s", err.Error())
+					log.Error().Msgf("extractTarGz: Copy() failed: %s", err.Error())
 				}
 				outFile.Close()
 

--- a/pkg/k3d/config.go
+++ b/pkg/k3d/config.go
@@ -8,11 +8,11 @@ package k3d
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"runtime"
 
 	"github.com/caarlos0/env/v6"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -70,13 +70,12 @@ func GetConfig(clusterName string, gitProvider string, gitOwner string) *K3dConf
 	config := K3dConfig{}
 
 	if err := env.Parse(&config); err != nil {
-		log.Println("something went wrong loading the environment variables")
-		log.Panic(err)
+		log.Error().Msgf("something went wrong loading the environment variables: %s", err)
 	}
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		log.Panic(err)
+		log.Error().Msgf("something went wrong getting home path: %s", err)
 	}
 
 	// cGitHost describes which git host to use depending on gitProvider

--- a/pkg/k3d/secrets.go
+++ b/pkg/k3d/secrets.go
@@ -92,7 +92,8 @@ func AddK3DSecrets(
 		} else if strings.Contains(err.Error(), "not found") {
 			_, err = clientset.CoreV1().Secrets(secret.ObjectMeta.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 			if err != nil {
-				log.Fatal().Msgf("error creating kubernetes secret %s/%s: %s", secret.Namespace, secret.Name, err)
+				log.Error().Msgf("error creating kubernetes secret %s/%s: %s", secret.Namespace, secret.Name, err)
+				return err
 			}
 			log.Info().Msgf("created kubernetes secret: %s/%s", secret.Namespace, secret.Name)
 		}
@@ -120,7 +121,8 @@ func AddK3DSecrets(
 		} else if strings.Contains(err.Error(), "not found") {
 			_, err = clientset.CoreV1().ServiceAccounts(serviceAccount.ObjectMeta.Namespace).Create(context.TODO(), serviceAccount, metav1.CreateOptions{})
 			if err != nil {
-				log.Fatal().Msgf("error creating kubernetes service account %s/%s: %s", serviceAccount.Namespace, serviceAccount.Name, err)
+				log.Error().Msgf("error creating kubernetes service account %s/%s: %s", serviceAccount.Namespace, serviceAccount.Name, err)
+				return err
 			}
 			log.Info().Msgf("created kubernetes service account: %s/%s", serviceAccount.Namespace, serviceAccount.Name)
 		}

--- a/pkg/k3d/ssl.go
+++ b/pkg/k3d/ssl.go
@@ -91,7 +91,8 @@ func GenerateTLSSecrets(clientset *kubernetes.Clientset, config K3dConfig) error
 				},
 			}, metav1.CreateOptions{})
 			if err != nil {
-				log.Fatal().Msgf("error creating kubernetes secret %s/%s: %s", app.Namespace, app.AppName, err)
+				log.Error().Msgf("error creating kubernetes secret %s/%s: %s", app.Namespace, app.AppName, err)
+				return err
 			}
 			log.Info().Msgf("created kubernetes secret: %s/%s", app.Namespace, app.AppName)
 		}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -36,12 +36,12 @@ func CreateKubeConfig(inCluster bool, kubeConfigPath string) *KubernetesClient {
 	if inCluster {
 		config, err := rest.InClusterConfig()
 		if err != nil {
-			panic(err.Error())
+			log.Errorf("error creating kubernetes config: %s", err)
 		}
 
 		clientset, err := kubernetes.NewForConfig(config)
 		if err != nil {
-			panic(err.Error())
+			log.Errorf("error creating kubernetes client: %s", err)
 		}
 
 		return &KubernetesClient{
@@ -66,13 +66,13 @@ func CreateKubeConfig(inCluster bool, kubeConfigPath string) *KubernetesClient {
 	// Build configuration instance from the provided config file
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
-		log.Fatalf("unable to locate kubeconfig file - checked path: %s", kubeconfig)
+		log.Errorf("unable to locate kubeconfig file - checked path: %s", kubeconfig)
 	}
 
 	// Create clientset, which is used to run operations against the API
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		panic(err)
+		log.Errorf("error creating kubernetes client: %s", err)
 	}
 
 	return &KubernetesClient{

--- a/pkg/k8s/util.go
+++ b/pkg/k8s/util.go
@@ -41,7 +41,8 @@ func WaitForJobComplete(clientset *kubernetes.Clientset, job *batchv1.Job, timeo
 		Jobs(job.ObjectMeta.Namespace).
 		Watch(context.Background(), watchOptions)
 	if err != nil {
-		log.Fatal().Msgf("error when attempting to wait for Job: %s", err)
+		log.Error().Msgf("error when attempting to wait for Job: %s", err)
+		return false, err
 	}
 	log.Info().Msgf("waiting for %s Job completion. This could take up to %v seconds.", job.Name, timeoutSeconds)
 

--- a/pkg/vultr/bootstrapSecrets.go
+++ b/pkg/vultr/bootstrapSecrets.go
@@ -80,7 +80,8 @@ func BootstrapVultrMgmtCluster(vultrApiKey string, kubeconfigPath string, gitPro
 		} else if strings.Contains(err.Error(), "not found") {
 			_, err = clientset.CoreV1().Secrets(secret.ObjectMeta.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 			if err != nil {
-				log.Fatal().Msgf("error creating kubernetes secret %s/%s: %s", secret.Namespace, secret.Name, err)
+				log.Error().Msgf("error creating kubernetes secret %s/%s: %s", secret.Namespace, secret.Name, err)
+				return err
 			}
 			log.Info().Msgf("created kubernetes secret: %s/%s", secret.Namespace, secret.Name)
 		}
@@ -108,7 +109,8 @@ func BootstrapVultrMgmtCluster(vultrApiKey string, kubeconfigPath string, gitPro
 		} else if strings.Contains(err.Error(), "not found") {
 			_, err = clientset.CoreV1().ServiceAccounts(serviceAccount.ObjectMeta.Namespace).Create(context.TODO(), serviceAccount, metav1.CreateOptions{})
 			if err != nil {
-				log.Fatal().Msgf("error creating kubernetes service account %s/%s: %s", serviceAccount.Namespace, serviceAccount.Name, err)
+				log.Error().Msgf("error creating kubernetes service account %s/%s: %s", serviceAccount.Namespace, serviceAccount.Name, err)
+				return err
 			}
 			log.Info().Msgf("created kubernetes service account: %s/%s", serviceAccount.Namespace, serviceAccount.Name)
 		}

--- a/pkg/vultr/config.go
+++ b/pkg/vultr/config.go
@@ -8,11 +8,11 @@ package vultr
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"runtime"
 
 	"github.com/kubefirst/runtime/pkg"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -61,7 +61,7 @@ func GetConfig(clusterName string, domainName string, gitProvider string, gitOwn
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		log.Panic(err.Error())
+		log.Error().Msgf("something went wrong getting home path: %s", err)
 	}
 
 	// cGitHost describes which git host to use depending on gitProvider

--- a/pkg/vultr/vultr.go
+++ b/pkg/vultr/vultr.go
@@ -89,7 +89,7 @@ func (c *VultrConfiguration) TestDomainLiveness(domainName string) bool {
 			}
 		}
 		if count == 100 {
-			log.Panic().Msg("unable to resolve domain dns record. please check your domain registrar")
+			log.Error().Msg("unable to resolve domain dns record. please check your domain registrar")
 		}
 	}
 	return true


### PR DESCRIPTION
when this was embedded in the cli, it made sense to use log.fatal/panic, but this is a runtime library now and should properly return an error when something happens. this causes the api to panic and exit rather than just present an error to the user.