### PR TITLE
feat: add delete buckets func for aws and vultr

### DIFF
--- a/pkg/aws/s3.go
+++ b/pkg/aws/s3.go
@@ -66,6 +66,24 @@ func (conf *AWSConfiguration) CreateBucket(bucketName string) (*s3.CreateBucketO
 	return bucket, nil
 }
 
+// DeleteBucket
+func (conf *AWSConfiguration) DeleteBucket(bucketName string) error {
+	s3Client := s3.NewFromConfig(conf.Config)
+
+	// Create bucket
+	log.Info().Msgf("deleting s3 bucket %s", bucketName)
+	s3DeleteBucketInput := &s3.DeleteBucketInput{
+		Bucket: aws.String(bucketName),
+	}
+
+	_, err := s3Client.DeleteBucket(context.Background(), s3DeleteBucketInput)
+	if err != nil {
+		return fmt.Errorf("error deleting s3 bucket %s: %s", bucketName, err)
+	}
+
+	return nil
+}
+
 func (conf *AWSConfiguration) ListBuckets() (*s3.ListBucketsOutput, error) {
 	fmt.Println("listing buckets")
 	s3Client := s3.NewFromConfig(conf.Config)

--- a/pkg/vultr/objectStorage.go
+++ b/pkg/vultr/objectStorage.go
@@ -60,6 +60,28 @@ func (c *VultrConfiguration) CreateObjectStorage(region string, storeName string
 	return govultr.ObjectStorage{}, err
 }
 
+// DeleteObjectStorage deletes a Vultr object storage resource
+func (c *VultrConfiguration) DeleteObjectStorage(region string, storeName string) error {
+	// Get object storage id
+	res, _, _, err := c.Client.ObjectStorage.List(c.Context, &govultr.ListOptions{
+		Label: storeName,
+	})
+	if err != nil {
+		return fmt.Errorf("error listing object storage: %s", err)
+	}
+
+	if len(res) == 0 {
+		return fmt.Errorf("could not find object storage %s", storeName)
+	}
+
+	err = c.Client.ObjectStorage.Delete(c.Context, res[0].ID)
+	if err != nil {
+		return fmt.Errorf("error deleting object storage: %s", err)
+	}
+
+	return nil
+}
+
 // GetObjectStorage retrieves all Vultr object storage resources
 func (c *VultrConfiguration) GetObjectStorage(region string) ([]govultr.ObjectStorage, error) {
 	objst, _, _, err := c.Client.ObjectStorage.List(c.Context, &govultr.ListOptions{


### PR DESCRIPTION
can't do this for digitalocean because the user has to create the space where the bucket is created prior to running kubefirst, so it would be worthless to delete the bucket but not the space.