### PR TITLE
feat: add support for https only connections

### DIFF
--- a/pkg/gitClient/git.go
+++ b/pkg/gitClient/git.go
@@ -50,6 +50,7 @@ func CloneRefSetMain(gitRef, repoLocalPath, repoURL string) (*git.Repository, er
 
 	repo, err := Clone(gitRef, repoLocalPath, repoURL)
 	if err != nil {
+		log.Error().Msgf("error cloning repo (%s) at: %s, err: %v", repoURL, repoLocalPath, err)
 		return nil, err
 	}
 

--- a/pkg/k3d/config.go
+++ b/pkg/k3d/config.go
@@ -96,7 +96,8 @@ func GetConfig(clusterName string, gitProvider string, gitOwner string) *K3dConf
 	config.DestinationMetaphorRepoHttpsURL = fmt.Sprintf("https://%s/%s/metaphor.git", cGitHost, gitOwner)
 	config.DestinationMetaphorRepoGitURL = fmt.Sprintf("git@%s:%s/metaphor.git", cGitHost, gitOwner)
 
-	if strings.Contains(viper.GetString("git-protocol"), "https") {
+	// Define constant url based on flag input, only expecting 2 protocols
+	if strings.Contains(viper.GetString("flags.git-protocol"), "https") {
 		config.DestinationGitopsRepoURL = config.DestinationGitopsRepoHttpsURL
 
 	} else {

--- a/pkg/k3d/config.go
+++ b/pkg/k3d/config.go
@@ -10,9 +10,11 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/caarlos0/env/v6"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -48,6 +50,7 @@ type K3dConfig struct {
 
 	DestinationGitopsRepoHttpsURL   string
 	DestinationGitopsRepoGitURL     string
+	DestinationGitopsRepoURL        string
 	DestinationMetaphorRepoHttpsURL string
 	DestinationMetaphorRepoGitURL   string
 	GitopsDir                       string
@@ -93,6 +96,13 @@ func GetConfig(clusterName string, gitProvider string, gitOwner string) *K3dConf
 	config.DestinationMetaphorRepoHttpsURL = fmt.Sprintf("https://%s/%s/metaphor.git", cGitHost, gitOwner)
 	config.DestinationMetaphorRepoGitURL = fmt.Sprintf("git@%s:%s/metaphor.git", cGitHost, gitOwner)
 
+	if strings.Contains(viper.GetString("git-protocol"), "https") {
+		config.DestinationGitopsRepoURL = config.DestinationGitopsRepoHttpsURL
+
+	} else {
+		config.DestinationGitopsRepoURL = config.DestinationGitopsRepoGitURL
+	}
+
 	config.GitopsDir = fmt.Sprintf("%s/.k1/%s/gitops", homeDir, clusterName)
 	config.GitProvider = gitProvider
 	config.K1Dir = fmt.Sprintf("%s/.k1/%s", homeDir, clusterName)
@@ -132,6 +142,7 @@ type GitopsTokenValues struct {
 	MetaphorDevelopmentIngressURL string
 	MetaphorStagingIngressURL     string
 	MetaphorProductionIngressURL  string
+	GitopsRepoURL                 string
 	KubefirstVersion              string
 	KubefirstTeam                 string
 	UseTelemetry                  string

--- a/pkg/k3d/config.go
+++ b/pkg/k3d/config.go
@@ -52,6 +52,7 @@ type K3dConfig struct {
 	DestinationMetaphorRepoGitURL   string
 	GitopsDir                       string
 	GitProvider                     string
+	GitProtocol                     string
 	K1Dir                           string
 	K3dClient                       string
 	Kubeconfig                      string
@@ -116,6 +117,7 @@ type GitopsTokenValues struct {
 	GitlabOwnerGroupID            int
 	GitlabUser                    string
 	GitopsRepoGitURL              string
+	GitopsRepoHttpsURL            string
 	DomainName                    string
 	AtlantisAllowList             string
 	AlertsEmail                   string

--- a/pkg/k3d/create.go
+++ b/pkg/k3d/create.go
@@ -122,7 +122,7 @@ func PrepareGitRepositories(
 	//* clone the gitops-template repo
 	gitopsRepo, err := gitClient.CloneRefSetMain(gitopsTemplateBranch, gitopsDir, gitopsTemplateURL)
 	if err != nil {
-		log.Info().Msgf("error opening repo at: %s, err: %v", gitopsDir, err)
+		log.Panic().Msgf("error opening repo at: %s, err: %v", gitopsDir, err)
 	}
 	log.Info().Msg("gitops repository clone complete")
 

--- a/pkg/k3d/create.go
+++ b/pkg/k3d/create.go
@@ -107,45 +107,47 @@ func PrepareGitRepositories(
 	gitProvider string,
 	clusterName string,
 	clusterType string,
-	destinationGitopsRepoGitURL string,
+	DestinationGitopsRepoHttpsURL string,
 	gitopsDir string,
 	gitopsTemplateBranch string,
 	gitopsTemplateURL string,
-	destinationMetaphorRepoGitURL string,
+	destinationMetaphorRepoHttpsURL string,
 	k1Dir string,
 	gitopsTokens *GitopsTokenValues,
 	metaphorDir string,
 	metaphorTokens *MetaphorTokenValues,
+	gitProtocol string,
 ) error {
 
 	//* clone the gitops-template repo
 	gitopsRepo, err := gitClient.CloneRefSetMain(gitopsTemplateBranch, gitopsDir, gitopsTemplateURL)
 	if err != nil {
-		log.Info().Msgf("error opening repo at: %s", gitopsDir)
+		log.Info().Msgf("error opening repo at: %s, err: %v", gitopsDir, err)
 	}
 	log.Info().Msg("gitops repository clone complete")
 
 	//* adjust the content for the gitops repo
 	err = AdjustGitopsRepo(CloudProvider, clusterName, clusterType, gitopsDir, gitProvider, k1Dir)
 	if err != nil {
+		log.Info().Msgf("err: %v", err)
 		return err
 	}
 
 	//* detokenize the gitops repo
-	detokenizeGitGitops(gitopsDir, gitopsTokens)
+	detokenizeGitGitops(gitopsDir, gitopsTokens, gitProtocol)
 	if err != nil {
 		return err
 	}
 
 	//* add new remote
-	err = gitClient.AddRemote(destinationGitopsRepoGitURL, gitProvider, gitopsRepo)
+	err = gitClient.AddRemote(DestinationGitopsRepoHttpsURL, gitProvider, gitopsRepo)
 	if err != nil {
 		return err
 	}
 
 	//! metaphor
 	//* adjust the content for the gitops repo
-	err = AdjustMetaphorRepo(destinationMetaphorRepoGitURL, gitopsDir, gitProvider, k1Dir)
+	err = AdjustMetaphorRepo(destinationMetaphorRepoHttpsURL, gitopsDir, gitProvider, k1Dir)
 	if err != nil {
 		return err
 	}
@@ -164,7 +166,7 @@ func PrepareGitRepositories(
 	}
 
 	//* add new remote
-	err = gitClient.AddRemote(destinationMetaphorRepoGitURL, gitProvider, metaphorRepo)
+	err = gitClient.AddRemote(destinationMetaphorRepoHttpsURL, gitProvider, metaphorRepo)
 	if err != nil {
 		return err
 	}

--- a/pkg/k3d/detokenize.go
+++ b/pkg/k3d/detokenize.go
@@ -71,6 +71,7 @@ func detokenizeGitops(path string, tokens *GitopsTokenValues, gitProtocol string
 				newContents = strings.Replace(newContents, "<GITHUB_OWNER>", strings.ToLower(tokens.GithubOwner), -1)
 				newContents = strings.Replace(newContents, "<GITHUB_USER>", tokens.GithubUser, -1)
 				newContents = strings.Replace(newContents, "<GIT_PROVIDER>", tokens.GitProvider, -1)
+				newContents = strings.Replace(newContents, "<GIT-PROTOCOL>", gitProtocol, -1)
 				newContents = strings.Replace(newContents, "<GITLAB_HOST>", tokens.GitlabHost, -1)
 				newContents = strings.Replace(newContents, "<GITLAB_OWNER>", tokens.GitlabOwner, -1)
 				newContents = strings.Replace(newContents, "<GITLAB_USER>", tokens.GitlabUser, -1)

--- a/pkg/k3d/detokenize.go
+++ b/pkg/k3d/detokenize.go
@@ -83,8 +83,10 @@ func detokenizeGitops(path string, tokens *GitopsTokenValues, gitProtocol string
 				// Switch the repo url based on https flag
 				if strings.Contains(gitProtocol, "https") {
 					newContents = strings.Replace(newContents, "<GITOPS_REPO_URL>", tokens.GitopsRepoHttpsURL, -1)
+					newContents = strings.Replace(newContents, "<GIT_FQDN>", "https://github.com/", -1)
 				} else {
 					newContents = strings.Replace(newContents, "<GITOPS_REPO_URL>", tokens.GitopsRepoGitURL, -1)
+					newContents = strings.Replace(newContents, "<GIT_FQDN>", "git@github.com:", -1)
 				}
 
 				err = ioutil.WriteFile(path, []byte(newContents), 0)

--- a/pkg/k3d/detokenize.go
+++ b/pkg/k3d/detokenize.go
@@ -83,10 +83,10 @@ func detokenizeGitops(path string, tokens *GitopsTokenValues, gitProtocol string
 				// Switch the repo url based on https flag
 				if strings.Contains(gitProtocol, "https") {
 					newContents = strings.Replace(newContents, "<GITOPS_REPO_URL>", tokens.GitopsRepoHttpsURL, -1)
-					newContents = strings.Replace(newContents, "<GIT_FQDN>", "https://github.com/", -1)
+					newContents = strings.Replace(newContents, "<GIT_FQDN>", fmt.Sprintf("https://%v.com/", tokens.GitProvider), -1)
 				} else {
 					newContents = strings.Replace(newContents, "<GITOPS_REPO_URL>", tokens.GitopsRepoGitURL, -1)
-					newContents = strings.Replace(newContents, "<GIT_FQDN>", "git@github.com:", -1)
+					newContents = strings.Replace(newContents, "<GIT_FQDN>", fmt.Sprintf("git@%v.com:", tokens.GitProvider), -1)
 				}
 
 				err = ioutil.WriteFile(path, []byte(newContents), 0)

--- a/pkg/k3d/detokenize.go
+++ b/pkg/k3d/detokenize.go
@@ -18,9 +18,9 @@ import (
 )
 
 // detokenizeGitGitops - Translate tokens by values on a given path
-func detokenizeGitGitops(path string, tokens *GitopsTokenValues) error {
+func detokenizeGitGitops(path string, tokens *GitopsTokenValues, gitProtocol string) error {
 
-	err := filepath.Walk(path, detokenizeGitops(path, tokens))
+	err := filepath.Walk(path, detokenizeGitops(path, tokens, gitProtocol))
 	if err != nil {
 		return err
 	}
@@ -28,7 +28,7 @@ func detokenizeGitGitops(path string, tokens *GitopsTokenValues) error {
 	return nil
 }
 
-func detokenizeGitops(path string, tokens *GitopsTokenValues) filepath.WalkFunc {
+func detokenizeGitops(path string, tokens *GitopsTokenValues, gitProtocol string) filepath.WalkFunc {
 	return filepath.WalkFunc(func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -71,7 +71,6 @@ func detokenizeGitops(path string, tokens *GitopsTokenValues) filepath.WalkFunc 
 				newContents = strings.Replace(newContents, "<GITHUB_OWNER>", strings.ToLower(tokens.GithubOwner), -1)
 				newContents = strings.Replace(newContents, "<GITHUB_USER>", tokens.GithubUser, -1)
 				newContents = strings.Replace(newContents, "<GIT_PROVIDER>", tokens.GitProvider, -1)
-				newContents = strings.Replace(newContents, "<GITOPS_REPO_GIT_URL>", tokens.GitopsRepoGitURL, -1)
 				newContents = strings.Replace(newContents, "<GITLAB_HOST>", tokens.GitlabHost, -1)
 				newContents = strings.Replace(newContents, "<GITLAB_OWNER>", tokens.GitlabOwner, -1)
 				newContents = strings.Replace(newContents, "<GITLAB_USER>", tokens.GitlabUser, -1)
@@ -79,6 +78,13 @@ func detokenizeGitops(path string, tokens *GitopsTokenValues) filepath.WalkFunc 
 				newContents = strings.Replace(newContents, "<VAULT_INGRESS_URL>", tokens.VaultIngressURL, -1)
 				newContents = strings.Replace(newContents, "<USE_TELEMETRY>", tokens.UseTelemetry, -1)
 				newContents = strings.Replace(newContents, "<K3D_DOMAIN>", DomainName, -1)
+
+				// Switch the repo url based on https flag
+				if strings.Contains(gitProtocol, "https") {
+					newContents = strings.Replace(newContents, "<GITOPS_REPO_URL>", tokens.GitopsRepoHttpsURL, -1)
+				} else {
+					newContents = strings.Replace(newContents, "<GITOPS_REPO_URL>", tokens.GitopsRepoGitURL, -1)
+				}
 
 				err = ioutil.WriteFile(path, []byte(newContents), 0)
 				if err != nil {

--- a/pkg/k3d/secrets.go
+++ b/pkg/k3d/secrets.go
@@ -70,11 +70,11 @@ func AddK3DSecrets(
 	// Create secrets
 
 	// swap secret data based on https flag
-	data := map[string][]byte{}
-	if strings.Contains(destinationGitopsRepoURL, "https://") {
+	secretData := map[string][]byte{}
 
+	if strings.Contains(destinationGitopsRepoURL, "https") {
 		// http basic auth
-		data = map[string][]byte{
+		secretData = map[string][]byte{
 			"type":     []byte("git"),
 			"name":     []byte(fmt.Sprintf("%s-gitops", gitUser)),
 			"url":      []byte(destinationGitopsRepoURL),
@@ -83,7 +83,7 @@ func AddK3DSecrets(
 		}
 	} else {
 		// ssh
-		data = map[string][]byte{
+		secretData = map[string][]byte{
 			"type":          []byte("git"),
 			"name":          []byte(fmt.Sprintf("%s-gitops", gitUser)),
 			"url":           []byte(destinationGitopsRepoURL),
@@ -100,7 +100,7 @@ func AddK3DSecrets(
 				Annotations: map[string]string{"managed-by": "argocd.argoproj.io"},
 				Labels:      map[string]string{"argocd.argoproj.io/secret-type": "repository"},
 			},
-			Data: data,
+			Data: secretData,
 		},
 	}
 	for _, secret := range createSecrets {


### PR DESCRIPTION
Best approach I could come up with for adding https only support while retaining the most critical ssh functionality without a ton of bloat and following existing patterns. Open to changing pretty much anything. I ***would*** consider this a breaking change.

Testing: Github and local k3d only currently. 

Known issues: Methaphor is complaining about a secret conflict. Its looking for keys that are not in ci-secrets. Just need to update what keys it looks for. Will be fixed before this is moved out of draft

This PR relies on 
kubefirst PR: https://github.com/kubefirst/kubefirst/pull/1583
GitOps-Template PR: https://github.com/kubefirst/gitops-template/pull/498

Closes https://github.com/kubefirst/kubefirst/issues/1566