### PR TITLE
fix: return what can be found for root-creds instead of exiting

### DIFF
--- a/pkg/helpers/setup.go
+++ b/pkg/helpers/setup.go
@@ -22,17 +22,17 @@ func DisplayLogHints() {
 	fmt.Println(strings.Repeat("-", 48))
 }
 
-// GetCompletionFlags gets specific config flags to mark status of an install
-func GetCompletionFlags() CompletionFlags {
-	return CompletionFlags{
+// GetClusterStatusFlags gets specific config flags to mark status of an install
+func GetClusterStatusFlags() ClusterStatusFlags {
+	return ClusterStatusFlags{
 		CloudProvider: viper.GetString("kubefirst.cloud-provider"),
 		GitProvider:   viper.GetString("kubefirst.git-provider"),
 		SetupComplete: viper.GetBool("kubefirst.setup-complete"),
 	}
 }
 
-// SetCompletionFlags sets specific config flags to mark status of an install
-func SetCompletionFlags(cloudProvider string, gitProvider string) {
+// SetClusterStatusFlags sets specific config flags to mark status of an install
+func SetClusterStatusFlags(cloudProvider string, gitProvider string) {
 	viper.Set("kubefirst.cloud-provider", cloudProvider)
 	viper.Set("kubefirst.git-provider", gitProvider)
 	viper.Set("kubefirst.setup-complete", true)

--- a/pkg/helpers/types.go
+++ b/pkg/helpers/types.go
@@ -6,7 +6,7 @@ See the LICENSE file for more details.
 */
 package helpers
 
-type CompletionFlags struct {
+type ClusterStatusFlags struct {
 	CloudProvider string
 	GitProvider   string
 	SetupComplete bool


### PR DESCRIPTION
rather than exiting with an error if the cluster install is not fully complete, simply check to see if an install has progressed far enough for this command to work. if so, return what is available.

Addresses https://github.com/kubefirst/kubefirst/issues/1614