### PR TITLE
fix: clean up logic for dns resolution

### DIFF
--- a/pkg/civo/civo.go
+++ b/pkg/civo/civo.go
@@ -14,19 +14,9 @@ import (
 	"time"
 
 	"github.com/civo/civogo"
+	"github.com/kubefirst/runtime/pkg/dns"
 	"github.com/rs/zerolog/log"
 )
-
-// Some systems fail to resolve TXT records, so try to use Google as a backup
-var backupResolver = &net.Resolver{
-	PreferGo: true,
-	Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-		d := net.Dialer{
-			Timeout: time.Millisecond * time.Duration(10000),
-		}
-		return d.DialContext(ctx, network, "8.8.8.8:53")
-	},
-}
 
 // TestDomainLiveness checks Civo DNS for the liveness test record
 func (c *CivoConfiguration) TestDomainLiveness(domainName string, domainId string, region string) bool {
@@ -73,7 +63,7 @@ func (c *CivoConfiguration) TestDomainLiveness(domainName string, domainId strin
 		log.Info().Msgf("%s", civoRecordName)
 		ips, err := net.LookupTXT(civoRecordName)
 		if err != nil {
-			ips, err = backupResolver.LookupTXT(context.Background(), civoRecordName)
+			ips, err = dns.BackupResolver.LookupTXT(context.Background(), civoRecordName)
 		}
 
 		log.Info().Msgf("%s", ips)

--- a/pkg/digitalocean/digitalocean.go
+++ b/pkg/digitalocean/digitalocean.go
@@ -14,19 +14,9 @@ import (
 	"time"
 
 	"github.com/digitalocean/godo"
+	"github.com/kubefirst/runtime/pkg/dns"
 	"github.com/rs/zerolog/log"
 )
-
-// Some systems fail to resolve TXT records, so try to use Google as a backup
-var backupResolver = &net.Resolver{
-	PreferGo: true,
-	Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-		d := net.Dialer{
-			Timeout: time.Millisecond * time.Duration(10000),
-		}
-		return d.DialContext(ctx, network, "8.8.8.8:53")
-	},
-}
 
 func (c *DigitaloceanConfiguration) TestDomainLiveness(domainName string) bool {
 	doRecordName := "kubefirst-liveness"
@@ -73,7 +63,7 @@ func (c *DigitaloceanConfiguration) TestDomainLiveness(domainName string) bool {
 		log.Info().Msgf("%s", doRecordName)
 		ips, err := net.LookupTXT(fmt.Sprintf("%s.%s", doRecordName, domainName))
 		if err != nil {
-			ips, err = backupResolver.LookupTXT(context.Background(), doRecordName)
+			ips, err = dns.BackupResolver.LookupTXT(context.Background(), doRecordName)
 		}
 
 		log.Info().Msgf("%s", ips)

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/kubefirst/runtime/pkg"
-	awsinternal "github.com/kubefirst/runtime/pkg/aws"
 	"github.com/lixiangzhong/dnsutil"
 	"github.com/rs/zerolog/log"
 )
@@ -28,23 +27,9 @@ var (
 )
 
 // VerifyProviderDNS
-func VerifyProviderDNS(cloudProvider string, cloudRegion string, domainName string) error {
-	var nameServers []string
-
+func VerifyProviderDNS(cloudProvider string, cloudRegion string, domainName string, nameServers []string) error {
 	switch cloudProvider {
 	case "aws":
-		awsClient := &awsinternal.AWSConfiguration{
-			Config: awsinternal.NewAwsV2(cloudRegion),
-		}
-		hostedZoneID, err := awsClient.GetHostedZoneID(domainName)
-		if err != nil {
-			return err
-		}
-		hostedZone, err := awsClient.GetHostedZone(hostedZoneID)
-		if err != nil {
-			return err
-		}
-		nameServers = hostedZone.DelegationSet.NameServers
 	case "civo":
 		nameServers = CivoNameServers
 	case "digitalocean":

--- a/pkg/dns/resolver.go
+++ b/pkg/dns/resolver.go
@@ -1,0 +1,24 @@
+/*
+Copyright (C) 2021-2023, Kubefirst
+
+This program is licensed under MIT.
+See the LICENSE file for more details.
+*/
+package dns
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// BackupResolver provides a DNS resolver to fall back to if the primary one fails
+var BackupResolver = &net.Resolver{
+	PreferGo: true,
+	Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+		d := net.Dialer{
+			Timeout: time.Millisecond * time.Duration(10000),
+		}
+		return d.DialContext(ctx, network, "8.8.8.8:53")
+	},
+}


### PR DESCRIPTION
- centralize backup resolver
- remove dependency for aws package in dns package for `VerifyProviderDNS`
- instead require passing in dns nameservers for aws when calling `VerifyProviderDNS`
- add error returns to clarify why `VerifyProviderDNS` failed for aws