### PR TITLE
fix: vultr and gcp bootstrapping

### DIFF
--- a/pkg/gcp/bootstrapSecrets.go
+++ b/pkg/gcp/bootstrapSecrets.go
@@ -93,12 +93,6 @@ func BootstrapGCPMgmtCluster(
 				"cf-api-token":                   []byte(cloudflareAPIToken),
 			},
 		},
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "cloudflare-creds", Namespace: "cert-manager"},
-			Data: map[string][]byte{
-				"cf-api-token": []byte(cloudflareAPIToken),
-			},
-		},
 	}
 	for _, secret := range createSecrets {
 		_, err := clientset.CoreV1().Secrets(secret.ObjectMeta.Namespace).Get(context.TODO(), secret.ObjectMeta.Name, metav1.GetOptions{})

--- a/pkg/vultr/bootstrapSecrets.go
+++ b/pkg/vultr/bootstrapSecrets.go
@@ -99,12 +99,6 @@ func BootstrapVultrMgmtCluster(
 				"cf-api-token": []byte(cloudflareAPIToken),
 			},
 		},
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "cloudflare-creds", Namespace: "cert-manager"},
-			Data: map[string][]byte{
-				"cf-api-token": []byte(cloudflareAPIToken),
-			},
-		},
 	}
 	for _, secret := range createSecrets {
 		_, err := clientset.CoreV1().Secrets(secret.ObjectMeta.Namespace).Get(context.TODO(), secret.ObjectMeta.Name, metav1.GetOptions{})


### PR DESCRIPTION
remove secrets for origin ca certs from vultr and gcp