### PR TITLE
fix: allow gcp bootstrap secrets process ability to create cert-manager ns

### DIFF
--- a/pkg/gcp/bootstrapSecrets.go
+++ b/pkg/gcp/bootstrapSecrets.go
@@ -34,6 +34,7 @@ func BootstrapGCPMgmtCluster(
 	newNamespaces := []string{
 		"argocd",
 		"atlantis",
+		"cert-manager",
 		"external-dns",
 		"external-secrets-operator",
 	}


### PR DESCRIPTION
```
➜  ~    tail -f -n +1 /Users/jdietz/.k1/logs/log_1690579761.log 

2023-07-28T17:29 INF pkg/helpers.go:78 > Using config file: /Users/jdietz/.kubefirst
2023-07-28T17:29 INF cmd/gcp/create.go:139 > github.com ssh-ed25519

2023-07-28T17:29 INF cmd/gcp/create.go:198 > verifying github authentication
2023-07-28T17:29 INF runtime/pkg/handlers/GitHubHandler/github.go:173 > GitHub user: johndietz
2023-07-28T17:29 INF runtime/pkg/handlers/GitHubHandler/github.go:213 > the github owner role is: admin
2023-07-28T17:29 INF cmd/gcp/create.go:406 > kubefirst version configs.K1Version: v2.2.5 
2023-07-28T17:29 INF cmd/gcp/create.go:407 > cloning gitops-template repo url: https://github.com/kubefirst/gitops-template.git 
2023-07-28T17:29 INF cmd/gcp/create.go:408 > cloning gitops-template repo branch:  
2023-07-28T17:29 INF cmd/gcp/create.go:417 > checking authentication to required providers
2023-07-28T17:29 INF cmd/gcp/create.go:432 > already completed cloud credentials check - continuing
2023-07-28T17:29 INF cmd/gcp/create.go:481 > domain check already complete - continuing
2023-07-28T17:29 INF cmd/gcp/create.go:520 > already created gcp state store bucket - continuing
2023-07-28T17:29 INF cmd/gcp/create.go:557 > already completed github checks - continuing
2023-07-28T17:29 INF cmd/gcp/create.go:582 > already setup kbot user - continuing
2023-07-28T17:29 INF cmd/gcp/create.go:586 > validation and kubefirst cli environment check is complete
2023-07-28T17:29 INF cmd/gcp/create.go:626 > already completed download of dependencies to `$HOME/.k1/tools` - continuing
2023-07-28T17:29 INF cmd/gcp/create.go:700 > already completed gitops repo generation - continuing
2023-07-28T17:29 INF cmd/gcp/create.go:734 > already created GitHub Terraform resources
2023-07-28T17:29 INF cmd/gcp/create.go:772 > referencing gitops repository: https://github.com/kgetpods-biz/gitops.git
2023-07-28T17:29 INF cmd/gcp/create.go:773 > referencing metaphor repository: https://github.com/kgetpods-biz/metaphor.git
2023-07-28T17:29 INF cmd/gcp/create.go:830 > already pushed detokenized gitops repository content
2023-07-28T17:29 INF cmd/gcp/create.go:876 > already created GitHub Terraform resources
2023-07-28T17:29 WRN pkg/gcp/bootstrapSecrets.go:52 > namespace argocd already exists - skipping
2023-07-28T17:29 WRN pkg/gcp/bootstrapSecrets.go:52 > namespace atlantis already exists - skipping
2023-07-28T17:29 WRN pkg/gcp/bootstrapSecrets.go:52 > namespace external-dns already exists - skipping
2023-07-28T17:29 WRN pkg/gcp/bootstrapSecrets.go:52 > namespace external-secrets-operator already exists - skipping
2023-07-28T17:29 INF pkg/gcp/bootstrapSecrets.go:106 > kubernetes secret argocd/repo-credentials-template already created - skipping
2023-07-28T17:29 INF pkg/gcp/bootstrapSecrets.go:106 > kubernetes secret external-dns/civo-creds already created - skipping
2023-07-28T17:29 ERR pkg/gcp/bootstrapSecrets.go:110 > error creating kubernetes secret cert-manager/cloudflare-creds: namespaces "cert-manager" not found
2023-07-28T17:29 INF cmd/gcp/create.go:921 > Error adding kubernetes secrets for bootstrap
```