### PR TITLE
Feat cloudflare https container reg civo creds

### DIFF
--- a/pkg/civo/objectStorage.go
+++ b/pkg/civo/objectStorage.go
@@ -71,7 +71,7 @@ func (c *CivoConfiguration) GetAccessCredentials(credentialName string, region s
 			return civogo.ObjectStoreCredential{}, err
 		}
 
-		for i := 0; i < 30; i++ {
+		for i := 0; i < 12; i++ {
 			creds, err = c.getAccessCredentials(creds.ID, region)
 			if err != nil {
 				return civogo.ObjectStoreCredential{}, err

--- a/pkg/cloudflare/cloudflare.go
+++ b/pkg/cloudflare/cloudflare.go
@@ -6,6 +6,17 @@ See the LICENSE file for more details.
 */
 package cloudflare
 
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/kubefirst/runtime/pkg/dns"
+	"github.com/rs/zerolog/log"
+)
+
 // GetDNSDomains lists all available DNS domains
 func (c *CloudflareConfiguration) GetDNSDomains() ([]string, error) {
 	var domainList []string
@@ -20,4 +31,111 @@ func (c *CloudflareConfiguration) GetDNSDomains() ([]string, error) {
 	}
 
 	return domainList, nil
+}
+
+// GetDNSDomains lists all available DNS domains
+func (c *CloudflareConfiguration) GetDNSRecord() ([]string, error) {
+	var domainList []string
+
+	zones, err := c.Client.ListZones(c.Context)
+	if err != nil {
+		return []string{}, err
+	}
+
+	for _, domain := range zones {
+		domainList = append(domainList, domain.Name)
+	}
+
+	return domainList, nil
+}
+
+func (c *CloudflareConfiguration) TestDomainLiveness(domainName string) bool {
+	RecordName := "kubefirst-liveness"
+	RecordValue := "domain record propagated"
+
+	// Get zone id for domain name
+	zoneId, err := c.Client.ZoneIDByName(domainName)
+	if err != nil {
+		log.Error().Msgf("error finding cloudflare zoneid for domain %s: %s", domainName, err)
+		return false
+	}
+	rc := cloudflare.ZoneIdentifier(zoneId)
+
+	log.Info().Msgf("Cloudflare ZoneID %s exists and contains domain %s", zoneId, domainName)
+
+	// Change this for origin certs
+
+	log.Info().Msgf("checking to see if record %s exists", domainName)
+
+	// check for existing records
+
+	listParams := cloudflare.ListDNSRecordsParams{
+		Proxied: cloudflare.BoolPtr(false),
+		Type:    "TXT",
+		Name:    RecordName,
+		Content: RecordValue,
+	}
+	existingRecords, _, err := c.Client.ListDNSRecords(c.Context, rc, listParams)
+	if err != nil {
+		log.Error().Msgf("error getting digitalocean dns records for domain %s: %s", domainName, err)
+		return false
+	}
+	for _, existingRecord := range existingRecords {
+		if existingRecord.Type == "TXT" && existingRecord.Name == RecordName && existingRecord.Data == RecordValue {
+			return true
+		}
+	}
+
+	// create record if it does not exist
+	createParams := cloudflare.CreateDNSRecordParams{
+		Proxied: cloudflare.BoolPtr(false),
+		TTL:     5,
+		Type:    "TXT",
+		Name:    RecordName,
+		Content: RecordValue,
+		ZoneID:  zoneId,
+	}
+
+	record, err := c.Client.CreateDNSRecord(c.Context, rc, createParams)
+	if err != nil {
+		log.Error().Msgf(
+			"could not create kubeirst liveness TXT record on cloudflare zoneid %s for domain %s: %s",
+			domainName,
+			zoneId,
+			err,
+		)
+		return false
+	}
+	log.Info().Msg("Kubefirst DNS liveness TXT record created on Cloudflare")
+
+	count := 0
+	// todo need to exit after n number of minutes and tell them to check ns records
+	// todo this logic sucks
+	for count <= 100 {
+		count++
+
+		log.Info().Msgf("%s", record.Name)
+		ips, err := net.LookupTXT(fmt.Sprintf("%s.%s", record.Name, domainName))
+		if err != nil {
+			ips, err = dns.BackupResolver.LookupTXT(context.Background(), record.Name)
+		}
+
+		log.Info().Msgf("%s", ips)
+
+		if err != nil {
+			log.Warn().Msgf("Could not get record name %s - waiting 10 seconds and trying again: \nerror: %s", record.Name, err)
+			time.Sleep(10 * time.Second)
+		} else {
+			for _, ip := range ips {
+				// todo check ip against route53RecordValue in some capacity so we can pivot the value for testing
+				log.Info().Msgf("%s. in TXT record value: %s\n", record.Name, ip)
+				count = 101
+			}
+		}
+		if count == 100 {
+			log.Error().Msg("unable to resolve domain dns record. please check your domain registrar, ns records, and DNS host")
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/cloudflare/cloudflare.go
+++ b/pkg/cloudflare/cloudflare.go
@@ -50,7 +50,7 @@ func (c *CloudflareConfiguration) GetDNSRecord() ([]string, error) {
 }
 
 func (c *CloudflareConfiguration) TestDomainLiveness(domainName string) bool {
-	RecordName := "kubefirst-liveness"
+	RecordName := "kubefirst-liveness." + domainName
 	RecordValue := "domain record propagated"
 
 	// Get zone id for domain name
@@ -81,15 +81,14 @@ func (c *CloudflareConfiguration) TestDomainLiveness(domainName string) bool {
 		return false
 	}
 	for _, existingRecord := range existingRecords {
-		if existingRecord.Type == "TXT" && existingRecord.Name == RecordName && existingRecord.Data == RecordValue {
+		if existingRecord.Type == "TXT" && existingRecord.Name == RecordName && existingRecord.Content == RecordValue {
 			return true
 		}
 	}
 
 	// create record if it does not exist
 	createParams := cloudflare.CreateDNSRecordParams{
-		Proxied: cloudflare.BoolPtr(false),
-		TTL:     5,
+		TTL:     60,
 		Type:    "TXT",
 		Name:    RecordName,
 		Content: RecordValue,

--- a/pkg/providerConfigs/adjustDriver.go
+++ b/pkg/providerConfigs/adjustDriver.go
@@ -275,7 +275,7 @@ func PrepareGitRepositories(
 	}
 
 	//* add new remote for metaphor repo
-	err = gitClient.AddRemote(destinationGitopsRepoURL, gitProvider, metaphorRepo)
+	err = gitClient.AddRemote(destinationMetaphorRepoURL, gitProvider, metaphorRepo)
 	if err != nil {
 		return err
 	}

--- a/pkg/providerConfigs/config.go
+++ b/pkg/providerConfigs/config.go
@@ -76,21 +76,10 @@ func GetConfig(
 		cGitHost = GitlabHost
 	}
 
-	config.DestinationGitopsRepoHttpsURL = fmt.Sprintf("https://%s/%s/gitops.git", cGitHost, gitOwner)
+	config.DestinationGitopsRepoURL = fmt.Sprintf("https://%s/%s/gitops.git", cGitHost, gitOwner)
 	config.DestinationGitopsRepoGitURL = fmt.Sprintf("git@%s:%s/gitops.git", cGitHost, gitOwner)
-	config.DestinationMetaphorRepoHttpsURL = fmt.Sprintf("https://%s/%s/metaphor.git", cGitHost, gitOwner)
+	config.DestinationMetaphorRepoURL = fmt.Sprintf("https://%s/%s/metaphor.git", cGitHost, gitOwner)
 	config.DestinationMetaphorRepoGitURL = fmt.Sprintf("git@%s:%s/metaphor.git", cGitHost, gitOwner)
-
-	// Define constant url based on flag input, only expecting 2 protocols
-	switch gitProtocol {
-	case "https":
-		config.DestinationGitopsRepoURL = config.DestinationGitopsRepoHttpsURL
-		config.DestinationMetaphorRepoURL = config.DestinationMetaphorRepoHttpsURL
-	default: //"ssh"
-		config.DestinationGitopsRepoURL = config.DestinationGitopsRepoGitURL
-		config.DestinationMetaphorRepoURL = config.DestinationMetaphorRepoGitURL
-	}
-
 	config.ArgoWorkflowsDir = fmt.Sprintf("%s/.k1/%s/argo-workflows", homeDir, clusterName)
 	config.GitopsDir = fmt.Sprintf("%s/.k1/%s/gitops", homeDir, clusterName)
 	config.GitProvider = gitProvider

--- a/pkg/providerConfigs/detokenize.go
+++ b/pkg/providerConfigs/detokenize.go
@@ -121,7 +121,7 @@ func detokenizeGitops(path string, tokens *GitopsDirectoryValues, gitProtocol st
 				newContents = strings.Replace(newContents, "<METAPHOR_PRODUCTION_INGRESS_URL>", metaphorProductionIngressURL, -1)
 				newContents = strings.Replace(newContents, "<METAPHOR_STAGING_INGRESS_URL>", metaphorStagingIngressURL, -1)
 
-				// external-dns
+				// external-dns optionality to provide cloudflare support regardless of cloud provider
 				newContents = strings.Replace(newContents, "<EXTERNAL_DNS_PROVIDER_NAME>", tokens.ExternalDNSProviderName, -1)
 				newContents = strings.Replace(newContents, "<EXTERNAL_DNS_PROVIDER_TOKEN_ENV_NAME>", tokens.ExternalDNSProviderTokenEnvName, -1)
 				newContents = strings.Replace(newContents, "<EXTERNAL_DNS_PROVIDER_SECRET_NAME>", tokens.ExternalDNSProviderSecretName, -1)
@@ -132,6 +132,7 @@ func detokenizeGitops(path string, tokens *GitopsDirectoryValues, gitProtocol st
 				// Switch the repo url based on https flag
 				newContents = strings.Replace(newContents, "<GITOPS_REPO_URL>", tokens.GitopsRepoURL, -1)
 
+				//The fqdn is used by metaphor/argo to choose the appropriate url for cicd operations.
 				if gitProtocol == "https" {
 					newContents = strings.Replace(newContents, "<GIT_FQDN>", fmt.Sprintf("https://%v.com/", tokens.GitProvider), -1)
 				} else {


### PR DESCRIPTION
Following code breaks out some repeated logic into functions that can now be shared. 

It also refactors the https/git url protocol implementation such that there is the generic DestinationGitopsRepoUrl and then the DestinationGitopsRepoGitUrl which can be switch on based on the Git Protocol. 

It also adds logic to perform liveness tests on cloudflare DNS which we can work into the cli when we are ready. 